### PR TITLE
04 pars body and handle cors

### DIFF
--- a/node-rest-shop/api/routes/orders.js
+++ b/node-rest-shop/api/routes/orders.js
@@ -8,8 +8,13 @@ router.get('/', (req, res, next) => {
 });
 
 router.post('/', (req, res, next) => {
+    const order = {
+        productId: req.body.productId,
+        quantity: req.body.quantity
+    }
     res.status(201).json({
-        message: 'Orders was created'
+        message: 'Orders was created',
+        order: order
     });
 });
 

--- a/node-rest-shop/api/routes/products.js
+++ b/node-rest-shop/api/routes/products.js
@@ -8,8 +8,13 @@ router.get('/', (req, res, next) => {
 });
 
 router.post('/', (req, res, next) => {
+    const product = {
+        name: req.body.name,
+        price: req.body.price
+    }
     res.status(201).json({
-        message: 'handling POST requests to /products'
+        message: 'handling POST requests to /products',
+        createdProduct: product
     });
 });
 

--- a/node-rest-shop/app.js
+++ b/node-rest-shop/app.js
@@ -7,10 +7,24 @@ const bodyParser = require('body-parser')
 const productRoutes = require('./api/routes/products')
 const orderRoutes = require('./api/routes/orders')
 
+// Middleware
 app.use(morgan('dev'));
 app.use(bodyParser.urlencoded({extended: false}));
 app.use(bodyParser.json());
+app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requestd-With, Content-Type, Accept, Authorization'
+    );
+    if (req.method === 'OPTIONS') {
+        res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE');
+        return res.status(200).json({});
+    }
+    next();
+});
 
+// Routes
 app.use('/products', productRoutes);
 app.use('/orders', orderRoutes);
 

--- a/node-rest-shop/app.js
+++ b/node-rest-shop/app.js
@@ -2,11 +2,14 @@ const express = require('express');
 const app = express();
 // Middleware, logs each request
 const morgan = require('morgan');
+const bodyParser = require('body-parser')
 
 const productRoutes = require('./api/routes/products')
 const orderRoutes = require('./api/routes/orders')
 
 app.use(morgan('dev'));
+app.use(bodyParser.urlencoded({extended: false}));
+app.use(bodyParser.json());
 
 app.use('/products', productRoutes);
 app.use('/orders', orderRoutes);

--- a/node-rest-shop/package.json
+++ b/node-rest-shop/package.json
@@ -15,6 +15,7 @@
   "author": "Chris Tregaskis",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "morgan": "^1.10.0"
   },


### PR DESCRIPTION
- npm installed body-parser to use .json method. This returns middleware that only parses json and only looks at requests where the `Content-Type` header matches the `type` option.
- required in `app.js`
- included handling CORS and enabled any application access with the following verbs: GET, POST, PUT, PATCH, DELETE
- created `product` object in products.json on POST route that captures data sent via the request in the body and returns it
- created `order` object in orders.json on POST route that captures data sent via the request in the body and returns it